### PR TITLE
Wrong box size not detected by validator

### DIFF
--- a/layoutlm/layoutlm/data/funsd.py
+++ b/layoutlm/layoutlm/data/funsd.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import numpy as np
 
 import torch
 from torch.utils.data import Dataset
@@ -117,7 +118,8 @@ class InputFeatures(object):
         page_size,
     ):
         assert (
-            0 <= all(boxes) <= 1000
+            np.array(boxes).max() <= 1000
+            and np.array(boxes).min() >= 0
         ), "Error with input bbox ({}): the coordinate value is not between 0 and 1000".format(
             boxes
         )


### PR DESCRIPTION
Bug at line 121, all(boxes) does not detect when the value inside the bounding box is greater than 1000 or lower than 0, fixed it using numpy